### PR TITLE
docs(general): correct bower version separator from '@' to '#'

### DIFF
--- a/docs/config/templates/api/module.template.html
+++ b/docs/config/templates/api/module.template.html
@@ -22,7 +22,7 @@
     </li>
     <li>
       <a href="http://bower.io">Bower</a> e.g.
-      {% code %}bower install {$ doc.packageName $}@X.Y.Z{% endcode %}
+      {% code %}bower install {$ doc.packageName $}#X.Y.Z{% endcode %}
     </li>
     <li>
       <a href="https://code.angularjs.org/">code.angularjs.org</a>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Docs update

**What is the current behavior? (You can also link to an open issue here)**

bower syntax is incorrect, the docs says '@' instead of '#' to specify version

**What is the new behavior (if this is a feature change)?**

bower syntax is corrected

**Does this PR introduce a breaking change?**

No

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:
